### PR TITLE
Remove unused exception parameter from pymk/aggregator/early_stage_ranking/EarlyStageRanker.cpp

### DIFF
--- a/src/hf_tokenizer.cpp
+++ b/src/hf_tokenizer.cpp
@@ -138,7 +138,7 @@ Error HFTokenizer::load(const std::string& path) {
   try {
     _decoder =
         TokenDecoderConfig().parse_json(parsed_json.at("decoder")).create();
-  } catch (const json::out_of_range& e) {
+  } catch (const json::out_of_range&) {
     // No decoder specified
   }
 


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968824


