### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setup(
     version="0.1.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/pytorch-labs/tokenizers",
+    url="https://github.com/meta-pytorch/tokenizers",
     packages=find_packages(),
     ext_modules=[CMakeExtension("pytorch_tokenizers_cpp")],
     cmdclass={"build_ext": CMakeBuild},


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:27:12.151289+00:00Z