### PR TITLE
Forward fix tekken tokenizer for internal test

### DIFF
--- a/include/pytorch/tokenizers/tekken.h
+++ b/include/pytorch/tokenizers/tekken.h
@@ -49,6 +49,7 @@ class Tekken : public detail::BPETokenizerBase {
   };
 
   explicit Tekken();
+  ~Tekken() override = default;
 
   // Load from tekken.json file
   Error load(const std::string& tokenizer_path) override;

--- a/targets.bzl
+++ b/targets.bzl
@@ -172,6 +172,29 @@ def define_common_targets():
         platforms = PLATFORMS,
     )
 
+    runtime.cxx_library(
+        name = "tekken",
+        srcs = [
+            "src/tekken.cpp",
+        ],
+        deps = [
+            ":regex",
+        ],
+        exported_deps = [
+            ":bpe_tokenizer_base",
+            ":headers",
+        ],
+        exported_external_deps = [
+            "re2",
+            "nlohmann_json",
+        ],
+        visibility = [
+            "@EXECUTORCH_CLIENTS",
+            "//pytorch/tokenizers/...",
+        ],
+        platforms = PLATFORMS,
+    )
+
     runtime.cxx_python_extension(
         name = "pytorch_tokenizers_cpp",
         srcs = [
@@ -186,6 +209,7 @@ def define_common_targets():
             ":hf_tokenizer",
             ":llama2c_tokenizer",
             ":sentencepiece",
+            ":tekken",
             ":tiktoken",
         ],
         external_deps = [


### PR DESCRIPTION
Summary:
allow-large-files
bypass-github-export-checks
bypass-github-pytorch-ci-checks
bypass-github-executorch-ci-checks
bypass-github-torchtune-ci-checks
diff-train-skip-merge

Reviewed By: jackzhxng

Differential Revision: D81598484


