### PR TITLE
Update tokenizers-config for Windows

### DIFF
--- a/cmake/tokenizers-config.cmake.in
+++ b/cmake/tokenizers-config.cmake.in
@@ -10,7 +10,11 @@ include(CMakeFindDependencyMacro)
 include(GNUInstallDirs)
 # Directly include sentencepiece library
 set_and_check(TOKENIZERS_LIBDIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
-set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/libsentencepiece.a")
+if(WIN32)
+    set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/libsentencepiece.lib")
+else()
+    set(SENTENCEPIECE_LIBRARY "${TOKENIZERS_LIBDIR}/libsentencepiece.a")
+endif()
 if(NOT EXISTS "${SENTENCEPIECE_LIBRARY}")
   message(
     FATAL_ERROR


### PR DESCRIPTION
The tokenizers-config CMake file needs to be updated to use the .lib extension on Windows, instead of .a, for the tokenizers library. This allows tokenizers to be referenced via find_package on Windows. This was an oversight in https://github.com/meta-pytorch/tokenizers/pull/121.