### PR TITLE
Keep the lookahead regex fallback linked, and report Tiktoken setup errors instead of aborting

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -28,6 +28,11 @@ jobs:
         cmake --build build/test -j9 --config Debug
         pushd build/test && ctest && popd
 
+        # The test build turns the lookahead fallback on, so nothing else here
+        # compiles the branch that leaves it out.
+        cmake -DCMAKE_BUILD_TYPE=Debug -DSUPPORT_REGEX_LOOKAHEAD=OFF . -Bbuild/no-lookahead
+        cmake --build build/no-lookahead -j9 --config Debug
+
         # Install tokenizers
         pip install . -v
         pip install protobuf pytest blobfile transformers>=4.53.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ if(SUPPORT_REGEX_LOOKAHEAD)
   )
   target_link_options_shared_lib(regex_lookahead)
   target_link_libraries(tokenizers PUBLIC regex_lookahead)
+  target_compile_definitions(tokenizers PRIVATE SUPPORT_REGEX_LOOKAHEAD)
   install(
     TARGETS regex_lookahead pcre2-8-static
     EXPORT tokenizers-targets

--- a/include/pytorch/tokenizers/tiktoken.h
+++ b/include/pytorch/tokenizers/tiktoken.h
@@ -40,12 +40,7 @@ class Tiktoken : public detail::BPETokenizerBase {
       : _pattern(std::move(pattern)),
         _special_tokens(std::move(special_tokens)),
         _bos_token_index(bos_token_index),
-        _eos_token_index(eos_token_index) {
-    if (_bos_token_index >= _special_tokens->size() ||
-        _eos_token_index >= _special_tokens->size()) {
-      abort();
-    }
-  }
+        _eos_token_index(eos_token_index) {}
 
   explicit Tiktoken(
       std::string pattern,

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -21,7 +21,20 @@ static Result<std::unique_ptr<IRegex>> default_create_fallback_regex(
   return tokenizers::Error::RegexFailure;
 }
 
+#ifdef SUPPORT_REGEX_LOOKAHEAD
+// Declared here instead of in the public header because it exists only when
+// regex_lookahead.cpp is built. Naming it is also what keeps that file in the
+// link: a translation unit that only registers itself from a static
+// initializer has nothing pointing at it, so the linker drops it out of a
+// static archive unless the whole archive is force-loaded, and the Apple
+// frameworks merge everything into one archive without that flag.
+Result<std::unique_ptr<IRegex>> create_fallback_regex(
+    const std::string& pattern);
+
+FallbackRegexFn fallback_regex = create_fallback_regex;
+#else
 FallbackRegexFn fallback_regex = default_create_fallback_regex;
+#endif
 
 bool register_override_fallback_regex(FallbackRegexFn fn) {
   TK_LOG(Info, "Registering override fallback regex");
@@ -59,13 +72,20 @@ Result<std::unique_ptr<IRegex>> create_regex(const std::string& pattern) {
     return static_cast<std::unique_ptr<IRegex>>(std::move(re2));
   }
 
-  auto res = get_fallback_regex()(pattern);
-  if (!res.ok()) {
+  auto fallback = get_fallback_regex();
+  auto res = fallback(pattern);
+  if (res.ok()) {
+    return res;
+  }
+  // Asking the pointer, not the build flags, keeps the advice right under both
+  // build systems: only CMake defines SUPPORT_REGEX_LOOKAHEAD, while buck links
+  // the same fallback in through its own whole-archive setting.
+  if (fallback == default_create_fallback_regex) {
     TK_LOG(
         Error,
-        "RE2 doesn't support lookahead patterns. Link with `regex_lookahead` to enable support.");
+        "RE2 could not compile the pattern and no fallback regex engine is linked. Turn on SUPPORT_REGEX_LOOKAHEAD, or depend on the regex_lookahead target, to support patterns such as lookahead.");
   } else {
-    return res;
+    TK_LOG(Error, "No available regex engine could compile the pattern.");
   }
 
   return tokenizers::Error::RegexFailure;

--- a/src/tiktoken.cpp
+++ b/src/tiktoken.cpp
@@ -133,6 +133,19 @@ void Tiktoken::_decode(const std::string& input, std::string& ret) const {
 // -------------------------public method start-------------------------------
 
 Error Tiktoken::load(const std::string& path) {
+  // Callers reach this through a fall-through chain of tokenizer loaders, so a
+  // badly configured Tiktoken has to be reportable rather than fatal.
+  TK_CHECK_OR_RETURN_ERROR(
+      _special_tokens != nullptr, LoadFailure, "no special tokens provided");
+  TK_CHECK_OR_RETURN_ERROR(
+      _bos_token_index < _special_tokens->size() &&
+          _eos_token_index < _special_tokens->size(),
+      LoadFailure,
+      "bos index %zu and eos index %zu must both be below the special token count %zu",
+      _bos_token_index,
+      _eos_token_index,
+      _special_tokens->size());
+
   auto token_map_result = _load_token_map(path);
   if (!token_map_result.ok()) {
     return token_map_result.error();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,3 +46,31 @@ foreach(test_source_file ${test_source_files})
   add_test(${test_name} "${test_name}")
   set_tests_properties(${test_name} PROPERTIES ENVIRONMENT ${test_env})
 endforeach()
+
+# The lookahead fallback registers itself from a static initializer, so the
+# linker keeps it only if something references it. Every test above hides that,
+# because linking the tokenizers target pulls regex_lookahead in with a
+# whole-archive flag. This one names the archive files instead, so nothing is
+# force loaded, which is the shape the Apple prebuilt frameworks have and the
+# only shape that fails when the reference goes away.
+add_executable(regex_lookahead_link_test regex_lookahead_link_test.cpp)
+# Naming the archive files skips the usage requirements a target would carry, so
+# the headers have to be compiled the same way the archive was.
+target_include_directories(
+  regex_lookahead_link_test
+  PRIVATE $<TARGET_PROPERTY:tokenizers,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(
+  regex_lookahead_link_test
+  PRIVATE $<TARGET_PROPERTY:tokenizers,INTERFACE_COMPILE_DEFINITIONS>
+)
+target_link_libraries(
+  regex_lookahead_link_test
+  PRIVATE gtest_main $<TARGET_FILE:tokenizers> $<TARGET_FILE:regex_lookahead>
+          pcre2-8-static re2::re2 sentencepiece-static
+)
+add_dependencies(regex_lookahead_link_test tokenizers regex_lookahead)
+add_test(regex_lookahead_link_test regex_lookahead_link_test)
+set_tests_properties(
+  regex_lookahead_link_test PROPERTIES ENVIRONMENT ${test_env}
+)

--- a/test/regex_lookahead_link_test.cpp
+++ b/test/regex_lookahead_link_test.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Built by a target that links the static archives directly, with no
+// whole-archive flag, so that it fails if regex.cpp stops referencing the
+// lookahead fallback. See the comment on that target in CMakeLists.txt.
+
+#include <gtest/gtest.h>
+#include <pytorch/tokenizers/regex.h>
+
+namespace tokenizers {
+
+TEST(RegexLookaheadLinkTest, LookaheadPatternCompiles) {
+  auto regex = create_regex(R"(\s+(?!\S))");
+  EXPECT_TRUE(regex.ok());
+}
+
+} // namespace tokenizers

--- a/test/test_tiktoken.cpp
+++ b/test/test_tiktoken.cpp
@@ -188,42 +188,38 @@ TEST_F(TiktokenTest, TestDecodeSpecialTokens) {
   EXPECT_EQ(res_true.get(), "");
 }
 
-TEST_F(TiktokenTest, ConstructionWithInvalidBOSIndex) {
-  // gtest death test doesn't work on iOS:
-  // https://github.com/google/googletest/issues/2834
-#if !GTEST_OS_IOS
-  EXPECT_EXIT(
-      std::make_unique<Tiktoken>(
-          std::make_unique<std::vector<std::string>>(
-              std::vector<std::string>{"<|end_of_text|>"}),
-          1,
-          0),
-#if !GTEST_OS_WINDOWS
-      ::testing::KilledBySignal(SIGABRT),
-#else
-      [](int exit_code) { return exit_code != 0; },
-#endif
-      "");
-#endif
+TEST_F(TiktokenTest, LoadWithInvalidBOSIndex) {
+  Tiktoken tokenizer(
+      std::make_unique<std::vector<std::string>>(
+          std::vector<std::string>{"<|end_of_text|>"}),
+      1,
+      0);
+  EXPECT_EQ(tokenizer.load(modelPath_), Error::LoadFailure);
 }
 
-TEST_F(TiktokenTest, ConstructionWithInvalidEOSIndex) {
-  // gtest death test doesn't work on iOS:
-  // https://github.com/google/googletest/issues/2834
-#if !GTEST_OS_IOS
-  EXPECT_EXIT(
-      std::make_unique<Tiktoken>(
-          std::make_unique<std::vector<std::string>>(
-              std::vector<std::string>{"<|begin_of_text|>"}),
-          0,
-          1),
-#if !GTEST_OS_WINDOWS
-      ::testing::KilledBySignal(SIGABRT),
-#else
-      [](int exit_code) { return exit_code != 0; },
-#endif
-      "");
-#endif
+TEST_F(TiktokenTest, LoadWithInvalidEOSIndex) {
+  Tiktoken tokenizer(
+      std::make_unique<std::vector<std::string>>(
+          std::vector<std::string>{"<|begin_of_text|>"}),
+      0,
+      1);
+  EXPECT_EQ(tokenizer.load(modelPath_), Error::LoadFailure);
+}
+
+TEST_F(TiktokenTest, LoadWithEmptySpecialTokens) {
+  Tiktoken tokenizer(
+      std::make_unique<std::vector<std::string>>(),
+      kBOSTokenIndex,
+      kEOSTokenIndex);
+  EXPECT_EQ(tokenizer.load(modelPath_), Error::LoadFailure);
+}
+
+TEST_F(TiktokenTest, LoadWithNullSpecialTokens) {
+  Tiktoken tokenizer(
+      std::unique_ptr<std::vector<std::string>>(),
+      kBOSTokenIndex,
+      kEOSTokenIndex);
+  EXPECT_EQ(tokenizer.load(modelPath_), Error::LoadFailure);
 }
 
 TEST_F(TiktokenTest, TestLoadInvalidPath) {


### PR DESCRIPTION
Addresses both halves of pytorch/executorch#21805.

ExecuTorch consumes this repository through a submodule pin, and the Apple
frameworks are built from that pin, so this change reaches iOS users only after
the pin is moved forward. That bump is not part of this PR.

## Problem

An app that loads a current HuggingFace `tokenizer.json` (Qwen2, Qwen3, LFM2, and
anything else descended from GPT-2) through the prebuilt Apple frameworks dies
with signal 6. The device console shows:

```
E0000 re2.cc:237] Error parsing '((?i:'s|'t|...': invalid perl operator: (?!
E tokenizers:regex.cpp:66] RE2 doesn't support lookahead patterns.
E tokenizers:hf_tokenizer.cpp:482] Failed to setup pretokenizer: Error: 9
App terminated due to signal 6.
```

Two separate bugs combine to produce that.

### 1. The lookahead fallback is compiled but never linked

Those tokenizers use the negative lookahead `\s+(?!\S)` in their pretokenizer
pattern. RE2 cannot compile it, so the code is supposed to fall back to PCRE2,
which lives in `regex_lookahead.cpp`.

That file installs itself from a static initializer and nothing else refers to
it. A linker pulls an object out of a static archive only when something already
in the link needs a symbol that object defines, so with nothing pointing at it
the object is dropped and the initializer never runs. CMake works around that
with `target_link_options_shared_lib`, which adds `-force_load`. That is a link
option, so it disappears as soon as many archives are merged into one, and
merging is exactly what the Apple framework build does.

So `regex_lookahead.o` does ship inside the prebuilt library. The app just never
links it, and every lookahead pattern fails.

### 2. Tiktoken aborts instead of reporting the failure

Once the pretokenizer fails, the loader falls through to `Tiktoken`. Its
constructor called `abort()` when the BOS or EOS index sat outside the special
token list. A caller that supplied an empty list therefore killed the process,
with nothing to catch.

## Solution

### 1. Refer to the fallback from code, not from a link flag

`regex.cpp` now initializes the fallback function pointer to
`create_fallback_regex` directly, under a new `SUPPORT_REGEX_LOOKAHEAD` compile
definition that CMake sets on the same target it already builds the fallback
for. That is an ordinary undefined symbol, so a merged archive keeps the object
with no special flags.

The tradeoff is that the dependency becomes mandatory and ordered. Where
`libtokenizers.a` used to link on its own, it now needs `libregex_lookahead.a`,
and a single pass linker needs that archive listed after it rather than before.
CMake sets the definition only on the target that also builds the fallback, so
the two always travel together there. The static initializer stays in place, so
the buck build, which force loads the target instead, is unchanged. The
declaration is kept out of the public header because the function exists only in
builds that have the fallback.

### 2. Move the bounds check into `Tiktoken::load()`

It now returns `Error::LoadFailure` and logs the two indices and the list size.
`load()` also rejects a null special token list, which used to be a null
dereference. Nothing reads those members before `load()` runs, so there is no new
way to go out of bounds. A caller walking a chain of tokenizer loaders can move
on to the next one instead of dying.

### 3. Pick the diagnostic at run time

The old message named lookahead for every pattern RE2 rejected, which is
misleading when the pattern simply has a syntax error. The message now depends on
whether a fallback engine is actually registered: if one is, the pattern is
reported as unsupported by every engine; if none is, the message says how to link
one.

## Test plan

Built and run on Linux x86_64, GCC 11.5, CMake with Ninja.

The full test suite passes, 15 of 15, including a new `regex_lookahead_link_test`.
That new target links the archives by file, so nothing is force loaded. That
stands in for the merged Apple archive, where member selection works the same
way. It is the only test that can see this bug: with the new reference in
`regex.cpp` removed it is the single failing test out of 15, and it prints

```
E tokenizers:regex.cpp:84] RE2 could not compile the pattern and no fallback regex engine is linked. Turn on SUPPORT_REGEX_LOOKAHEAD, or depend on the regex_lookahead target, to support patterns such as lookahead.
```

while `test_regex`, `test_hf_tokenizer` and `test_tiktoken` all still pass.

`test_tiktoken` covers the rejected setups separately, and each was checked
against the code with the guard removed:

| test | what it passes | result |
|---|---|---|
| `LoadWithNullSpecialTokens` | a null list | `LoadFailure`, "no special tokens provided"; segfaults without the guard |
| `LoadWithEmptySpecialTokens` | an empty list | `LoadFailure`, "bos index 0 and eos index 1 must both be below the special token count 0" |
| `LoadWithInvalidBOSIndex` | one token, bos 1 | `LoadFailure` |
| `LoadWithInvalidEOSIndex` | one token, eos 1 | `LoadFailure` |

Imitated the Apple link by merging every produced `.a` into one archive with
`ar -M` and linking with no force load flag, then loading a real Qwen2.5
`tokenizer.json`:

| | before | after |
|---|---|---|
| `create_fallback_regex` in the binary | absent | present |
| loading the tokenizer | fails, then signal 6 | loads |

Encodings from that build match the Python `tokenizers` package exactly,
including runs of several spaces, which is the case the lookahead governs:

```
"Hello world"      -> 9707 1879
"a  b   c"         -> 64 220 293 256 272
"日本語のテスト"      -> 101059 102819 15767 140592
```

That last check needs a Qwen2.5 `tokenizer.json`, which is not in the repository,
so it is not reproducible from this PR alone.

Built with `SUPPORT_REGEX_LOOKAHEAD` both ON and OFF, and compiled the changed
files with `-Wall -Werror` in both, clean. The Linux job now builds the library
with the option off as well, because the test build always turns it on and
nothing else in CI compiled that branch.

CI is green. The C++ suite runs on Linux and macOS and passes 15 of 15 on both,
including the new test. The Windows job builds the library with MSVC and runs
the Python tests, which reach the fallback on real HuggingFace patterns
(`Creating PCRE2 regex`), so the changed lines compile and run under MSVC too.

Not tested: an actual iOS device, Android, and the buck build.
