### PR TITLE
Fix the hugging face tokenizer build issues (#211)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -144,13 +144,11 @@ runtime.cxx_library(
         ":regex",
     ],
     exported_deps = [
+        "fbsource//third-party/nlohmann-json:nlohmann-json",
         "fbsource//third-party/re2:re2",
         ":bpe_tokenizer_base",
         ":headers",
         "//pytorch/tokenizers/third-party:unicode",
-    ],
-    exported_external_deps = [
-        "nlohmann_json",
     ],
 )
 

--- a/include/pytorch/tokenizers/hf_tokenizer.h
+++ b/include/pytorch/tokenizers/hf_tokenizer.h
@@ -78,7 +78,7 @@ class HFTokenizer : public detail::BPETokenizerBase {
    * Default initialize with no loaded data
    */
   explicit HFTokenizer() {}
-  ~HFTokenizer() {}
+  ~HFTokenizer() override {}
 
   /**
    * Load the model data into the


### PR DESCRIPTION
Summary:

- Move `nlohmann-json` from `exported_external_deps` to `exported_deps` to fix compatibility with certain build configurations. The explicit `"fbsource//third-party/nlohmann-json:nlohmann-json"` dep is already used in the headers target so it felt like a safe change.
- Add override to `~HFTokenizer()` to fix `-Winconsistent-missing-destructor-override warning`.

Differential Revision: D117725862


