### PR TITLE
[RELEASE ONLY CHANGES] Fix tokenizers 1.5 wheel CI

### DIFF
--- a/.github/workflows/build-wheels-linux-aarch64.yml
+++ b/.github/workflows/build-wheels-linux-aarch64.yml
@@ -21,12 +21,12 @@ on:
 jobs:
   generate-matrix:
     name: Generate Linux AArch64 matrix
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -37,12 +37,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: meta-pytorch/tokenizers
       ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
       package-name: pytorch_tokenizers

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -21,12 +21,12 @@ on:
 jobs:
   generate-matrix:
     name: Generate Linux matrix
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -37,12 +37,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: meta-pytorch/tokenizers
       ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
       package-name: pytorch_tokenizers

--- a/.github/workflows/build-wheels-macos-arm64.yml
+++ b/.github/workflows/build-wheels-macos-arm64.yml
@@ -21,12 +21,12 @@ on:
 jobs:
   generate-matrix:
     name: Generate macOS matrix
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: macos-arm64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -37,12 +37,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
     with:
       repository: meta-pytorch/tokenizers
       ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
       package-name: pytorch_tokenizers

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -21,12 +21,12 @@ on:
 jobs:
   generate-matrix:
     name: Generate Windows matrix
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: windows
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -37,12 +37,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@release/2.12
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
     with:
       repository: meta-pytorch/tokenizers
       ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: release/2.12
+      test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       trigger-event: ${{ github.event_name }}
       package-name: pytorch_tokenizers


### PR DESCRIPTION
### Summary

Moves the four wheel workflows from `pytorch/test-infra@release/2.12` to `pytorch/test-infra@main`, matching the ExecuTorch 1.5 release branch.

### Test plan

- `git diff --check`
- parsed all four changed workflow YAML files
- verified all referenced reusable workflows exist on `pytorch/test-infra@main`
- rely on PR wheel jobs to validate the shared workflow update, especially Linux AArch64

Authored with Codex.